### PR TITLE
Fix invocation of Github secret within workflow file

### DIFF
--- a/.github/workflows/clojure.yml
+++ b/.github/workflows/clojure.yml
@@ -52,6 +52,6 @@ jobs:
     - name: Release
       if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'kalai-transpiler/kalai'
       env:
-        CLOJARS_PASSWORD: ${CLOJARSTOKEN}
+        CLOJARS_PASSWORD: ${{ secrets.CLOJARSTOKEN }}
         CLOJARS_USERNAME: timothypratley
       run: make deploy


### PR DESCRIPTION
This should fix the release/deploy job. The change is in the syntax that references the secret from within the workflow file.

[Here is how I did my testing](https://github.com/kalai-transpiler/kalai/compare/main...echeran:kalai-fork:ci-fix-test) on a separate branch.  You can see [the results from the logs](https://github.com/echeran/kalai-fork/actions/runs/4039998525/jobs/6945241129#step:5:286) of the workflow instance.

(Side note: it's good that we use the `env:` section of the workflow job syntax to set the Clojars username and password. As you can see from the output, the workflow runner likes to print any commands in the `run:` section before executing them (like what Make does). So if we had a command like `... CLOJARS_PASSWORD=${blah} make deploy`, then we would have been putting the secret into the CI logs.)