### PR TITLE
Update version to 0.2.x

### DIFF
--- a/dev/build.clj
+++ b/dev/build.clj
@@ -3,7 +3,7 @@
             [deps-deploy.deps-deploy :as dd]))
 
 (def lib 'com.github.kalai-transpiler/kalai)
-(def version (format "0.1.%s" (b/git-count-revs nil)))
+(def version (format "0.2.%s" (b/git-count-revs nil)))
 (def class-dir "target/classes")
 (def basis (b/create-basis {:project "deps.edn"}))
 (def jar-file (format "target/%s-%s.jar" (name lib) version))


### PR DESCRIPTION
Even though our latest version badge on the top-level Readme says "0.1.1", there is still a version "0.1.231" from testing deployment to Clojars.

If we bump the version to "0.2.x", then we won't have to worry about systems using semantic versioning comparators that will want to sort "0.1.231" > "0.1.x" for another ~229 versions (and then give an error from Clojars when we get to the 231st edition and it thinks that we're trying to redeploy an existing artifact).